### PR TITLE
Removed secondary output

### DIFF
--- a/count_file_types.ps1
+++ b/count_file_types.ps1
@@ -30,8 +30,3 @@ Get-ChildItem -Path $path -Recurse -Force -File | ForEach-Object {
 
 Write-Output $counts
 Out-File -InputObject $counts -FilePath ".\file_counts.txt"
-
-foreach ($extensionType in $counts.Keys) {
-  $total = $counts[$extensionType]
-  Write-Output (100 / $total)
-}


### PR DESCRIPTION
Removed secondary output that was in the very early stages of calculating percent of good vs. corrupted files.